### PR TITLE
Add a configuration item for character encoding

### DIFF
--- a/embedded-api/com/flaptor/indextank/api/EmbeddedIndexEngine.java
+++ b/embedded-api/com/flaptor/indextank/api/EmbeddedIndexEngine.java
@@ -20,6 +20,7 @@ import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -99,6 +100,7 @@ public class EmbeddedIndexEngine {
     private final String environment;
     private final int basePort;
     private final File baseDir;
+    private final String characterEncoding;
     
     private IndexRecoverer.IndexStorageValue recoveryStorage;
     private String cassandraClusterHosts;
@@ -176,6 +178,11 @@ public class EmbeddedIndexEngine {
         
     	String defaultField = "text";
     	
+      if (configuration.containsKey("encoding")) {
+          characterEncoding = (String) configuration.get("encoding");
+      } else {
+          characterEncoding = Charset.defaultCharset().name();
+      }
     	
     	if (configuration.containsKey("log_based_storage")) {
     	    logBasedStorage = (Boolean)configuration.get("log_based_storage");
@@ -365,6 +372,10 @@ public class EmbeddedIndexEngine {
 
     public IndexerStatus getStatus() {
         return status;
+    }
+
+    public String getCharacterEncoding() {
+        return characterEncoding;
     }
     
     private void setIndexer(BoostingIndexer indexer) {

--- a/embedded-api/com/flaptor/indextank/api/IndexEngineApi.java
+++ b/embedded-api/com/flaptor/indextank/api/IndexEngineApi.java
@@ -55,9 +55,11 @@ import com.google.common.collect.Multimap;
 public class IndexEngineApi {
 
     protected final EmbeddedIndexEngine engine;
+    protected final String characterEncoding;
 
     public IndexEngineApi(EmbeddedIndexEngine engine) {
         this.engine = engine;
+        characterEncoding = engine.getCharacterEncoding();
     }
 
     public SearchResults search(String queryStr, 
@@ -173,4 +175,7 @@ public class IndexEngineApi {
         return engine.getSuggestor().complete(query, field);
     }
 
+    public String getCharacterEncoding() {
+        return characterEncoding;
+    }
 }

--- a/embedded-api/com/flaptor/indextank/api/resources/Autocomplete.java
+++ b/embedded-api/com/flaptor/indextank/api/resources/Autocomplete.java
@@ -16,11 +16,13 @@
 
 package com.flaptor.indextank.api.resources;
 
-import java.util.List;
-import java.util.logging.Logger;
-
 import com.flaptor.indextank.api.IndexEngineApi;
 import com.ghosthack.turismo.action.Action;
+
+import javax.servlet.http.HttpServletResponse;
+import java.io.UnsupportedEncodingException;
+import java.util.List;
+import java.util.logging.Logger;
 
 public class Autocomplete extends Action {
 
@@ -29,16 +31,25 @@ public class Autocomplete extends Action {
      */
     public void run() {
         IndexEngineApi api = (IndexEngineApi) ctx().getAttribute("api");
+        HttpServletResponse res = res();
+
+        String characterEncoding = api.getCharacterEncoding();
+        try {
+            req().setCharacterEncoding(characterEncoding);
+            res.setCharacterEncoding(characterEncoding);
+            res.setContentType("application/json");
+        } catch (UnsupportedEncodingException ignored) {
+        }
 
         String query = params("query");
         String field = params("field");
-        
-        if(field == null || field.isEmpty()) {
+
+        if (field == null || field.isEmpty()) {
             field = "text";
         }
 
         List<String> complete = api.complete(query, field);
-        
+
         print(complete.toString());
 
     }

--- a/embedded-api/com/flaptor/indextank/api/resources/Search.java
+++ b/embedded-api/com/flaptor/indextank/api/resources/Search.java
@@ -16,6 +16,7 @@
 
 package com.flaptor.indextank.api.resources;
 
+import java.io.UnsupportedEncodingException;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -34,9 +35,12 @@ import com.flaptor.indextank.rpc.RangeFilter;
 import com.flaptor.indextank.search.SearchResult;
 import com.flaptor.indextank.search.SearchResults;
 import com.ghosthack.turismo.action.Action;
+import com.ghosthack.turismo.servlet.Env;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multiset;
+
+import javax.servlet.http.HttpServletResponse;
 
 public class Search extends Action {
 
@@ -45,6 +49,15 @@ public class Search extends Action {
      */
     public void run() {
         IndexEngineApi api = (IndexEngineApi) ctx().getAttribute("api");
+        HttpServletResponse res = res();
+
+        String characterEncoding = api.getCharacterEncoding();
+        try {
+            req().setCharacterEncoding(characterEncoding);
+            res.setCharacterEncoding(characterEncoding);
+            res.setContentType("application/json");
+        } catch (UnsupportedEncodingException ignored) {
+        }
 
         String q = params("q");
         int start = QueryHelper.parseIntParam(params("start"), 0);
@@ -106,8 +119,8 @@ public class Search extends Action {
             // TODO Auto-generated catch block
             e.printStackTrace();
         }
-        
-        res().setStatus(503);
+
+        res.setStatus(503);
         print("Service unavailable"); // TODO: descriptive error msg
     }
 

--- a/sample-engine-config
+++ b/sample-engine-config
@@ -1,5 +1,6 @@
 {
-"max_variables": 3, 
+"encoding": "utf-8",
+"max_variables": 3,
 "functions": {"0": "-age"}, 
 "index_code": "dbajo", 
 "allows_facets": true, 


### PR DESCRIPTION
I add some code for character encoding configuration to "embedded-api". because this use for asian language(IndexEngineCJKAnalyzer or Lucene KoreanAnalyzer etc.). the config key named "encoding". please change it at will, if necessary.
