### PR TITLE
renaming end -> len, to match service API

### DIFF
--- a/embedded-api/com/flaptor/indextank/api/resources/Search.java
+++ b/embedded-api/com/flaptor/indextank/api/resources/Search.java
@@ -62,7 +62,7 @@ public class Search extends Action {
         String fetch = params("fetch");
         String snippet = params("snippet");
         int start = QueryHelper.parseIntParam(params("start"), 0);
-        int len = QueryHelper.parseIntParam(params("end"), 10);
+        int len = QueryHelper.parseIntParam(params("len"), 10);
         int function = QueryHelper.parseIntParam(params("function"), 0);
         Map<Integer, Double> vars = Maps.newHashMap();
         List<CategoryFilter> facetFilters = Lists.newArrayList();


### PR DESCRIPTION
embedded API's resources/Search.java uses **end** in the same way indextank-service API uses **len**.

We should keep it compatible, so clients can either use the hosted API for production, but an embedded API for testing.
