### PR TITLE
Fixing bug with Snippeter and German 'ß' character

### DIFF
--- a/src/main/java/com/flaptor/indextank/search/SnippetSearcher.java
+++ b/src/main/java/com/flaptor/indextank/search/SnippetSearcher.java
@@ -157,9 +157,8 @@ public class SnippetSearcher extends AbstractDocumentSearcher {
                 String termInText = tokens.get(i).getText();
                 
                 for (String termInQuery : termsForField) {
-                    if (termInQuery.endsWith("*") && termInText.startsWith(termInQuery.substring(0, termInQuery.length() - 1))) { 
-                        matches.add(new Pair<Integer, Integer>(i, termInQuery.length() - 1));
-                    } else if (termInQuery.equals(termInText)) {
+                    if ((termInQuery.endsWith("*") && termInText.startsWith(termInQuery.substring(0, termInQuery.length() - 1))) 
+                            || termInQuery.equals(termInText)) {
                         matches.add(new Pair<Integer, Integer>(i, termInText.length()));
                     }
                 }
@@ -189,8 +188,9 @@ public class SnippetSearcher extends AbstractDocumentSearcher {
             for (Pair<AToken, Integer> token : window.matches) {
                 escapeAndAppend(buff, text, current, token.first().getStartOffset());
                 buff.append(open);
+                int start = token.first().getStartOffset();
                 int endOffset = token.first().getEndOffset();
-                escapeAndAppend(buff, text, token.first().getStartOffset(), endOffset);
+                escapeAndAppend(buff, text, start, endOffset);
                 buff.append(close);
                 current = endOffset;
             }

--- a/src/main/java/com/flaptor/indextank/search/SnippetSearcher.java
+++ b/src/main/java/com/flaptor/indextank/search/SnippetSearcher.java
@@ -189,9 +189,10 @@ public class SnippetSearcher extends AbstractDocumentSearcher {
             for (Pair<AToken, Integer> token : window.matches) {
                 escapeAndAppend(buff, text, current, token.first().getStartOffset());
                 buff.append(open);
-                escapeAndAppend(buff, text, token.first().getStartOffset(), token.first().getStartOffset() + token.last());
+                int endOffset = token.first().getEndOffset();
+                escapeAndAppend(buff, text, token.first().getStartOffset(), endOffset);
                 buff.append(close);
-                current = token.first().getStartOffset() + token.last();
+                current = endOffset;
             }
 
             // let subclasses handle where snippets end

--- a/src/test/java/com/flaptor/indextank/search/SnippetSearcherTest.java
+++ b/src/test/java/com/flaptor/indextank/search/SnippetSearcherTest.java
@@ -138,6 +138,28 @@ public class SnippetSearcherTest extends IndexTankTestCase {
         assertTrue("less-than signs not encoded!", sr.getField("snippet_text").contains("&lt;"));
     }
 
+    @TestInfo(testType=UNIT)
+    public void testTokenizingChangesTokenLength() throws IOException, InterruptedException, ParseException {
+        double timestampBoost = System.currentTimeMillis() / 1000.0;
+        String docid = "docid";
+        // \u00df is 'LATIN SMALL LETTER SHARP S'
+        // ASCIIFoldingFilter converts it from 'ß' to 'ss'
+        // see http://www.fileformat.info/info/unicode/char/df/index.htm
+        String text = "Clown Ferdinand und der Fu\u00dfball player";
+        Document doc = new Document(ImmutableMap.of("text", text));
+        indexer.add(docid, doc, (int)timestampBoost, Maps.<Integer, Double>newHashMap());
+
+        String queryText = "fussball";
+        Query query = new Query(new TermQuery("text", queryText), queryText, null);
+
+        SearchResults srs = searcher.search(query, 0, 1, 0, ImmutableMap.of("snippet_fields", "text", "snippet_type", "html"));
+        SearchResult sr = srs.getResults().iterator().next();
+        String snippet = sr.getField("snippet_text");
+        assertNotNull("Snippet is null", snippet);
+        assertTrue("Search term not highlighted", snippet.contains("<b>Fu&szlig;ball</b>"));
+        assertTrue("Snippet lost space before highlighted term", snippet.contains("der "));
+        assertTrue("Snippet lost space after highlighted term", snippet.contains(" player"));
+    }
 
     @TestInfo(testType=UNIT)
     public void testFetchAll() throws IOException, InterruptedException {

--- a/src/test/java/com/flaptor/indextank/search/SnippetSearcherTest.java
+++ b/src/test/java/com/flaptor/indextank/search/SnippetSearcherTest.java
@@ -28,6 +28,7 @@ import com.flaptor.indextank.IndexTankTestCase;
 import com.flaptor.indextank.index.Document;
 import com.flaptor.indextank.index.IndexEngine;
 import com.flaptor.indextank.query.ParseException;
+import com.flaptor.indextank.query.PrefixTermQuery;
 import com.flaptor.indextank.query.AndQuery;
 import com.flaptor.indextank.query.Query;
 import com.flaptor.indextank.query.TermQuery;
@@ -155,6 +156,16 @@ public class SnippetSearcherTest extends IndexTankTestCase {
         SearchResults srs = searcher.search(query, 0, 1, 0, ImmutableMap.of("snippet_fields", "text", "snippet_type", "html"));
         SearchResult sr = srs.getResults().iterator().next();
         String snippet = sr.getField("snippet_text");
+        assertNotNull("Snippet is null", snippet);
+        assertTrue("Search term not highlighted", snippet.contains("<b>Fu&szlig;ball</b>"));
+        assertTrue("Snippet lost space before highlighted term", snippet.contains("der "));
+        assertTrue("Snippet lost space after highlighted term: " + snippet, snippet.contains(" player"));
+
+        query = new Query(new PrefixTermQuery("text", "fu"), "fu*", null);
+
+        srs = searcher.search(query, 0, 1, 0, ImmutableMap.of("snippet_fields", "text", "snippet_type", "html"));
+        sr = srs.getResults().iterator().next();
+        snippet = sr.getField("snippet_text");
         assertNotNull("Snippet is null", snippet);
         assertTrue("Search term not highlighted", snippet.contains("<b>Fu&szlig;ball</b>"));
         assertTrue("Snippet lost space before highlighted term", snippet.contains("der "));


### PR DESCRIPTION
When the snippeter ran on a doc containing a word like 'fußball' at the end of the field, it triggered a StringIndexOutOfBoundsException.  It happened because during tokenization, ASCIIFoldingFilter changed the 'ß' character into 'ss'.  But the Snippeter was calculating the length using the end offset from the expanded string ('fussball'), causing the error.  

I added a testcase to demonstrate the problem.  Please do a sanity check code read :)

-chris
